### PR TITLE
Abbreviate SHA-1 in output to client

### DIFF
--- a/eclipse-cla/src/main/java/org/eclipse/foundation/gerrit/validation/EclipseCommitValidationListener.java
+++ b/eclipse-cla/src/main/java/org/eclipse/foundation/gerrit/validation/EclipseCommitValidationListener.java
@@ -109,7 +109,7 @@ public class EclipseCommitValidationListener implements CommitValidationListener
 		
 		List<CommitValidationMessage> messages = new ArrayList<CommitValidationMessage>();
 		addSeparatorLine(messages);
-		messages.add(new CommitValidationMessage(String.format("Reviewing commit: %1$s", commit.getId()), false));
+		messages.add(new CommitValidationMessage(String.format("Reviewing commit: %1$s", commit.abbreviate(8).name()), false));
 		messages.add(new CommitValidationMessage(String.format("Authored by: %1$s <%2$s>", authorIdent.getName(), authorIdent.getEmailAddress()), false));
 		addEmptyLine(messages);
 		


### PR DESCRIPTION
getId().toString() returns an ugly internal JGit string listing the
current revision flags attached to the RevCommit.  This is not
interesting or relevant to the end-user of Gerrit.

Instead abbreviate the SHA-1 to be 8 hex digits and print that as a
clean string.  For most Git repositories this will be uniquely
identified.  It is shorter to use in commands like `git show` when the
end-user wants to inspect a commit that was rejected by the CLA
plugin.
