### PR TITLE
Restore previous semantic for committer check

### DIFF
--- a/eclipse-cla/pom.xml
+++ b/eclipse-cla/pom.xml
@@ -19,7 +19,7 @@
 	<name>CLA</name>
 	<properties>
 		<Gerrit-ApiType>plugin</Gerrit-ApiType>
-		<Gerrit-ApiVersion>3.2.2</Gerrit-ApiVersion>
+		<Gerrit-ApiVersion>3.3.0-SNAPSHOT</Gerrit-ApiVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
During migration to permission backend the committer check was changed.
Restore the previous semantic by checking for Submit permission of
refs/heads/* as it was the case prior to migration to permission
backend. Note, that a change in Gerrit core is needed for that. That's
why this change is built against 3.3.0-SNAPSHOT plugin API.

Signed-off-by: David Ostrovsky <david@ostrovsky.org>