### PR TITLE
Update to Gerrit plugin to fix issues with potential missed validation

### DIFF
--- a/src/main/java/org/eclipse/foundation/gerrit/validation/ValidationRequest.java
+++ b/src/main/java/org/eclipse/foundation/gerrit/validation/ValidationRequest.java
@@ -29,6 +29,8 @@ public abstract class ValidationRequest {
 
   public abstract String provider();
 
+  public abstract boolean strictMode();
+
   public static JsonAdapter<ValidationRequest> jsonAdapter(Moshi moshi) {
     return new AutoValue_ValidationRequest.MoshiJsonAdapter(moshi);
   }
@@ -44,6 +46,8 @@ public abstract class ValidationRequest {
     public abstract Builder commits(List<Commit> commits);
 
     public abstract Builder provider(String provider);
+
+    public abstract Builder strictMode(boolean strictMode);
 
     abstract ValidationRequest build();
   }


### PR DESCRIPTION
Cases where bad Gerrit repos are input could lead to misses in
validation. To enforce more strict measues, a new strict mode was
introduced to the validation API, which this PR makes use of. All
commits, regardless of project status will be strictly evaluated.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>